### PR TITLE
Fix: Clear chat history on logout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -449,4 +449,3 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   requestAnimationFrame(render);
 });
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,6 +273,7 @@ exitGame.on('click', () => {
   );
   smallConfirm.setCallback(() => {
     client.disconnect();
+    chat.clear();
     hideAllUi();
     mainMenu.show();
   });
@@ -326,6 +327,7 @@ loginForm.on('cancel', () => {
 
 characterSelect.on('cancel', () => {
   client.disconnect();
+  chat.clear();
   characterSelect.hide();
   mainMenu.show();
 });
@@ -447,3 +449,4 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   requestAnimationFrame(render);
 });
+

--- a/src/ui/chat.ts
+++ b/src/ui/chat.ts
@@ -25,6 +25,10 @@ export class Chat extends Base {
     this.chatWindow.scrollTo(0, this.chatWindow.scrollHeight);
   }
 
+  clear() {
+    this.chatWindow.innerHTML = '';
+  }
+
   focus() {
     this.message.focus();
   }
@@ -71,3 +75,4 @@ export class Chat extends Base {
     this.emitter.on(event, handler);
   }
 }
+

--- a/src/ui/chat.ts
+++ b/src/ui/chat.ts
@@ -75,4 +75,3 @@ export class Chat extends Base {
     this.emitter.on(event, handler);
   }
 }
-


### PR DESCRIPTION
- Add clear() method to Chat class
- Call chat.clear() on exit game and character select cancel
- Resolves issue where chat messages persisted after logout



